### PR TITLE
Use original way to dl sprockets manifest

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,11 @@ mkdir -p $build_dir/public/assets
 mkdir -p $build_dir/public/packs
 
 # Sprockets
-download_file assets/.sprockets-manifest-$SOURCE_VERSION.json assets/.sprockets-manifest-$SOURCE_VERSION.json
+# Trying original way again:
+download_file assets/manifest-$SOURCE_VERSION.json || \
+  download_file assets/manifest-latest.json
+# Not working, but seemed better
+# download_file assets/.sprockets-manifest-$SOURCE_VERSION.json assets/.sprockets-manifest-$SOURCE_VERSION.json
+
 # Webpacker
 download_file packs/manifest.json packs/manifest.json


### PR DESCRIPTION
I think this may have been working here- 
https://github.com/arkency/heroku-buildpack-cdn-manifest/blob/master/bin/compile#L27-L28

Would like to test out different paths for this manifest, which is not currently working in its current form