### PR TITLE
exit 1 if manifests content type is xml

### DIFF
--- a/lib/download_file.sh
+++ b/lib/download_file.sh
@@ -4,6 +4,13 @@ download_file () {
   local remote_path=$1
   local local_path=$2
 
+  local content_type=$(curl "https://assets.userinterviews.com/${remote_path}" | grep -i "^Content-Type:")
+
+  if echo $content_type | grep -iq "application/xml"; then
+    echo "Invalid content type for manifest" | indent
+    return 1
+  fi
+
   curl "https://assets.userinterviews.com/${remote_path}" >> $build_dir/public/$local_path
 
   local status=$?


### PR DESCRIPTION
This should bail early and not write the manifest and log if either file is xml.  This should break builds, which is good. We can merge this before #8 and confirm before updating the paths to the manifests in s3