### PR TITLE
inverses logic content type check

### DIFF
--- a/lib/download_file.sh
+++ b/lib/download_file.sh
@@ -3,21 +3,18 @@
 download_file () {
   local remote_path=$1
   local local_path=$2
+  local file_url="https://assets.userinterviews.com/${remote_path}"
 
-  local content_type=$(curl "https://assets.userinterviews.com/${remote_path}" | grep -i "^Content-Type:")
+  if curl -s -I $file_url | grep -iq "application/json"; then
+    curl $file_url >> $build_dir/public/$local_path
 
-  if echo $content_type | grep -iq "application/xml"; then
+    local result=$?
+
+    echo "Downloaded remote file to $build_dir/public/$local_path" | indent
+
+    return 0
+  else
     echo "Invalid content type for manifest" | indent
     return 1
   fi
-
-  curl "https://assets.userinterviews.com/${remote_path}" >> $build_dir/public/$local_path
-
-  local status=$?
-
-  if [[ status -eq 0 ]]; then
-    echo "Downloaded remote file to $build_dir/public/$local_path" | indent
-  fi
-
-  return $status
 }


### PR DESCRIPTION
Rather than checking if content type is xml, we can instead check if it's JSON and proceed, otherwise bail