### PR TITLE
Add details about s3 file path

### DIFF
--- a/lib/download_file.sh
+++ b/lib/download_file.sh
@@ -9,16 +9,16 @@ download_file () {
   if curl -s -I $file_url | grep -iq "application/zip,application/octet-stream"; then
     # download zip file
     curl $file_url >> $build_dir/public/$local_path
-    echo "Downloaded remote zip file to $build_dir/public/$local_path" 
+    echo "Downloaded remote zip file: $remote_path to $build_dir/public/$local_path"
 
     # unzip file then remove zip
     unzip -q $build_dir/public/$local_path -d $build_dir/public/
     rm $build_dir/public/$local_path
 
-    echo "Unzipped assets into $build_dir/public" 
+    echo "Unzipped assets into $build_dir/public"
   else
     # If the zip isn't downloaded & unpacked successfully, rails will attempt to precompile assets instead
-    echo "Compressed assets not found in S3!"
+    echo "Compressed assets not found in S3: $remote_path"
     echo "Falling back to rails assets:precompile"
   fi
 


### PR DESCRIPTION
Since we use the SHA in the filename - it would be nice to have this info for troubleshooting vs our current contents in s3 when Heroku builds don't work